### PR TITLE
remove return code from get_reviews method

### DIFF
--- a/server/models/review_model.py
+++ b/server/models/review_model.py
@@ -72,8 +72,7 @@ class ReviewModel(db.Model):
             'reviewee_id': x.reviewee_id,
             'title': x.title,
             'status': x.status,
-            'language': x.language,
-            'code': x.code
+            'language': x.language
         }
 
     @classmethod


### PR DESCRIPTION
- changed it so get_reviews wont return code, as initially these api calls are only used to populate the side bar.
![image](https://user-images.githubusercontent.com/23492778/97621647-94447e80-19f9-11eb-8694-355b1442a214.png)
